### PR TITLE
Readme sda-svc

### DIFF
--- a/.github/ci_tests/posix.yaml
+++ b/.github/ci_tests/posix.yaml
@@ -18,7 +18,7 @@ global:
     host: "cega-users"
     user: "legatest"
   db:
-    host: "sda-db"
+    host: "postgres-sda-db"
   elixir:
     pubKey: "token.pub"
   inbox:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,13 +102,15 @@ jobs:
         helm repo update
     - name: Install minio
       run: |
-        kubectl create secret generic minio-certs --from-file=LocalEGA-deploy-init/config/certs/s3.ca.crt --from-file=LocalEGA-deploy-init/config/certs/s3.ca.key
+        cp LocalEGA-deploy-init/config/certs/s3.ca.crt public.crt
+        cp LocalEGA-deploy-init/config/certs/s3.ca.key private.key
+        kubectl create secret generic minio-certs --from-file=public.crt --from-file=private.key
         MINIO_ACCESS=$(grep s3_archive_access_key LocalEGA-deploy-init/config/trace.yml | awk {'print $2'} | sed --expression 's/\"//g')
         MINIO_SECRET=$(grep s3_archive_secret_key LocalEGA-deploy-init/config/trace.yml | awk {'print $2'} | sed --expression 's/\"//g')
         helm install minio \
         --set accessKey=$MINIO_ACCESS,secretKey=$MINIO_SECRET,\
-        tls.enabled=true,tls.publicCrt=s3.ca.crt,tls.privateKey=s3.ca.key,tls.certSecret=minio-certs,\
-        persistence.enabled=false,service.port=443 stable/minio --version 4.0.0
+        tls.enabled=true,tls.certSecret=minio-certs,\
+        persistence.enabled=false,service.port=443 stable/minio --version 5.0.0
     - name: Wait for minio to become ready
       run: |
         RETRY_TIMES=0

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# SDA-helm
+
+[![GitHub](https://img.shields.io/github/license/neicnordic/sda-helm?style=plastic)](https://www.gnu.org/licenses/agpl-3.0)
+![GitHub Actions linter](https://github.com/neicnordic/sda-helm/workflows/Helm%20linter/badge.svg)
+![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/neicnordic/sda-helm?sort=semver&style=plastic)
+
+## Info
+
+This repositroy contains helmcharts for deploying a Sensitive Data Archive solution that is compatible with the European Ggenome Archives federated archiving model
+
+## sda-db
+
+This chart deploys a pre-configured database instance for Sensitive Data Archive, the schemas match European Ggenome Archives federated archiving model.
+
+## sda-mq
+
+This chart deploys a pre-configured message broker designed to work European Ggenome Archives federated archive setup
+
+## sda-svc
+
+This chart deploys the service components needed for the Sensitive Data Archive solution.

--- a/sda-svc/README.md
+++ b/sda-svc/README.md
@@ -63,6 +63,7 @@ Parameter | Description | Default
 `global.db.passOutgest` | Password used for `data out` services. |`""`
 `global.db.port` | Port that the database is listening on. |`5432`
 `global.db.sslMode` | SSL mode for the database connection, options are `verify-ca` or `verify-full`. |`verify-full`
+`global.doa.serviceport` | Port that the DOA service is accessible on | `443`
 `global.elixir.pubKey` | Public key used to verify Elixir JWT. | `""`
 `global.inbox.brokerRoutingKey` | Routing key the inbox uses when publishing messages. | `files.inbox"`
 `global.inbox.servicePort` | The port that the inbox is accessible via. | `9000`

--- a/sda-svc/README.md
+++ b/sda-svc/README.md
@@ -1,0 +1,129 @@
+# SDA services
+
+## Installing the Chart
+
+Edit the values.yaml file and specify the relevant parts of the `global` section.  
+If no shared credentials for the broker and database are used, the credentials for each service shuld be set in the `credentials` section.
+
+### Configuration
+
+The following table lists the configurable parameters of the `sda-svc` chart and their default values.
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`global.secretsPath` |  | `/etc/ega`
+`global.c4ghPath` |  | `""`
+`global.tlsPath` |  | `""`
+`global.deploymentType` | Deployment can be split into `external` and `internal` components, available options are `all`, `external` and `internal`. | `all`
+`global.ingress.deploy` |  | `false`
+`global.ingress.hostName.doa` |  | `""`
+`global.ingress.hostName.s3Inbox` |  | `""`
+`global.ingress.secretNames.doa` | The name of a manually created secret holding the certificates for the ingrewss enpoint. | `""`
+`global.ingress.secretNames.s3Inbox` | The name of a manually created secret holding the certificates for the ingrewss enpoint. | `""`
+`global.ingress.issuer` | If cert-manager is set up to request certificates to the ingress endpoints, the configured issuer can be specified to automate certificate configuration for the ingress endpoint. | `""`
+`global.log` | Log level for all services. | `info`
+`global.networkPolicy.create` | Use network isolation. | `false`
+`global.networkPolicy.brokerNamespace` | Namespace where the broker is deployed. | `""`
+`global.networkPolicy.databaseNamespace` | Namespace where the database is deployed. | `""`
+`global.networkPolicy.externalNamespace` | Namespace where the external components are deployed. | `""`
+`global.networkPolicy.internalNamespace` | Namespace where the internal components are deployed. | `""`
+`global.persistence.enabled` | Enable persistent datastorage | `true`
+`global.revisionHistory` | Number of revisions to keep for the option to rollback a deployment | `3`
+`global.podAnnotations` | Annotations applied to pods of all services. |`{}`
+`global.pkiService` | If an external PKI infrastructure is used set this to true. |`false`
+`global.rbacEnabled` | Use role based access control. |`true`
+`global.archive.storageType` | Storage type for the data archive, available options are `S3Storage` and `FileStorage`. |`S3Storage`
+`global.archive.s3Url` | URL to S3 archive instance. |`""`
+`global.archive.s3Bucket` | S3 archive bucket. |`""`
+`global.archive.s3Region` | S3 archive region. |`us-east-1`
+`global.archive.s3ChunkSize` | S3 chunk size in MB. |`15`
+`global.archive.s3AccessKey` | Access key to S3 archive . |`""`
+`global.archive.s3SecretKey` | Secret key to S3 archive. |`""`
+`global.archive.s3CaFile` | CA certificate to use if the S3 archive is internal. |`""`
+`global.archive.s3Port` | Port that the S3 S3 archive is available on. |`443`
+`global.archive.volumePath` | Path to the mounted `FileStorage` volume. |`/ega/archive`
+`global.archive.volumeMode` | File mode on the `FileStorage` volume. |`2750`
+`global.archive.nfsServer` | URL or IP addres to a NFS server. |`""`
+`global.archive.nfsPath` | Path on the NFS server for the archive. |`""`
+`global.broker.host` | Domain name or IP address to the message broker. |`""`
+`global.broker.exchange` | Exchange to publish messages to. |`""`
+`global.broker.port` | Port for the message broker. |`5671`
+`global.broker.verifyPeer` | Use Client/Server verification. |`true`
+`global.broker.vhost` | Virtual host to connect to. |`/`
+`global.broker.password` | Shared password to the message broker. |`/`
+`global.broker.username` | Shared user to the message broker. |`/`
+`global.cega.host` | Domain name for the EGA user authentication service. |`""`
+`global.cega.user` | Username for the EGA user authentication service. |`""`
+`global.cega.password` | Password for the EGA user authentication service. |`""`
+`global.c4gh.file` | Private C4GH key. |`c4gh.key`
+`global.c4gh.passphrase` | Passphrase for the private C4GH key. |`""`
+`global.db.host` | Hostname for the database. |`""`
+`global.db.name` | Database to connect to. |`lega`
+`global.db.passIngest` | Password used for `data in` services. |`""`
+`global.db.passOutgest` | Password used for `data out` services. |`""`
+`global.db.port` | Port that the database is listening on. |`5432`
+`global.db.sslMode` | SSL mode for the database connection, options are `verify-ca` or `verify-full`. |`verify-full`
+`global.elixir.pubKey` | Public key used to verify Elixir JWT. | `""`
+`global.inbox.brokerRoutingKey` | Routing key the inbox uses when publishing messages. | `files.inbox"`
+`global.inbox.servicePort` | The port that the inbox is accessible via. | `9000`
+`global.inbox.storageType` | Storage type for the inbox. |`FileStorage`
+`global.inbox.path` | Path to the mounted `FileStorage` volume. |`/ega/archive`
+`global.inbox.user` | Path to the mounted `FileStorage` volume. |`lega`
+`global.inbox.nfsServer` | URL or IP addres to a NFS server. |`""`
+`global.inbox.nfsPath` | Path on the NFS server for the archive. |`""`
+`global.inbox.existingClaim` | Existing volume to use for the `fileStorage` inbox. | `""`
+
+### Credentials
+
+If no shared credentials for the message broker and database are used these should be set in the `credentials` section of the values file.
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`credentials.doa.dbUser` | Databse user for doa | `""`
+`credentials.doa.dbPassword` | Database password for doa| `""`
+`credentials.finalize.dbUser` | Databse user for finalize | `""`
+`credentials.finalize.dbPassword` | Database password for finalize | `""`
+`credentials.finalize.mqUser` | Broker user for finalize | `""`
+`credentials.finalize.mqPassword` | Broker password for finalize | `""`
+`credentials.inbox.mqUser` | Broker user for inbox | `""`
+`credentials.inbox.mqPassword` | Broker password for inbox | `""`
+`credentials.ingest.dbUser` | Databse user for ingest | `""`
+`credentials.ingest.dbPassword` | Database password for ingest | `""`
+`credentials.ingest.mqUser` | Broker user for ingest  | `""`
+`credentials.ingest.mqPassword` | Broker password for ingest | `""`
+`credentials.verify.dbUser` | Databse user for verify | `""`
+`credentials.verify.dbPassword` | Database password for verify | `""`
+`credentials.verify.mqUser` | Broker user for verify | `""`
+`credentials.verify.mqPassword` | Broker password for verify | `""`
+
+### Pod settings
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`doa.replicaCount` | desired number of replicas | `1`
+`doa.repository` | dataedge container image repository | `neicnordic/sda-doa`
+`doa.imageTag` | dataedge container image version | `"latest"`
+`doa.imagePullPolicy` | dataedge container image pull policy | `Always`
+`doa.keystorePass` | keystore password | `changeit`
+`doa.annotations` | Specific annotation for doa | `{}`
+`finalize.repository` | inbox container image repository | `neicnordic/sda-base`
+`finalize.imageTag` | inbox container image version | `latest`
+`finalize.imagePullPolicy` | inbox container image pull policy | `Always`
+`finalize.annotations` | Specific annotation for finalize | `{}`
+`ingest.repository` | inbox container image repository | `neicnordic/sda-base`
+`ingest.imageTag` | inbox container image version | `latest`
+`ingest.imagePullPolicy` | inbox container image pull policy | `Always`
+`ingest.replicaCount` | desired number of ingest workers | `1`
+`ingest.annotations` | Specific annotation for ingest | `{}`
+`sftpInbox.repository` | inbox container image repository | `neicnordic/sda-inbox-sftp`
+`sftpInbox.imageTag` | inbox container image version | `latest`
+`sftpInbox.imagePullPolicy` | inbox container image pull policy | `Always`
+`sftpInbox.replicaCount`| desired number of sftpInbox containers | `1`
+`sftpInbox.keystorePass` | sftpInbox keystore password | `changeit`
+`sftpInbox.nodeHostname` | Node name if the sftp inbox  needs to be deployed on a specific node | `""`
+`sftpInbox.annotations` | Specific annotation for sftpInbox | `{}`
+`verify.repository` | inbox container image repository | `neicnordic/sda-base`
+`verify.imageTag` | inbox container image version | `latest`
+`verify.imagePullPolicy` | inbox container image pull policy | `Always`
+`verify.replicaCount`| desired number of verify containers | `1`
+`verify.annotations` | Specific annotation for verify | `{}`

--- a/sda-svc/README.md
+++ b/sda-svc/README.md
@@ -66,7 +66,7 @@ Parameter | Description | Default
 `global.doa.serviceport` | Port that the DOA service is accessible on | `443`
 `global.elixir.pubKey` | Public key used to verify Elixir JWT. | `""`
 `global.inbox.brokerRoutingKey` | Routing key the inbox uses when publishing messages. | `files.inbox"`
-`global.inbox.servicePort` | The port that the inbox is accessible via. | `9000`
+`global.inbox.servicePort` | The port that the inbox is accessible via. | `2222`
 `global.inbox.storageType` | Storage type for the inbox. |`FileStorage`
 `global.inbox.path` | Path to the mounted `FileStorage` volume. |`/ega/archive`
 `global.inbox.user` | Path to the mounted `FileStorage` volume. |`lega`

--- a/sda-svc/templates/doa-deploy.yaml
+++ b/sda-svc/templates/doa-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "sda.fullname" . }}-doa
   labels:
     role: doa
-    app: {{ template "sda.name" . }}-doa
+    app: {{ template "sda.fullname" . }}-doa
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.doa.name }}"
     release: {{ .Release.Name }}
@@ -15,12 +15,12 @@ spec:
   revisionHistoryLimit: {{ default "3" .Values.global.revisionHistory }}
   selector:
     matchLabels:
-      app: {{ template "sda.name" . }}-doa
+      app: {{ template "sda.fullname" . }}-doa
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "sda.name" . }}-doa
+        app: {{ template "sda.fullname" . }}-doa
         role: doa
         release: {{ .Release.Name }}
     spec:
@@ -73,9 +73,15 @@ spec:
           value: "true"
         - name: S3_BUCKET
           value: {{ .Values.global.archive.s3Bucket | quote}}
+        {{- if .Values.global.archive.s3CaFile }}
+        - name: S3_ROOT_CERT_PATH
+          value: "/etc/ssl/certs/java/ca.crt"
+        {{- end }}
       {{- end }}
-        - name: JWT_PUBLIC_KEY_PATH
+      {{- if .Values.global.elixir.pubKey }}
+        - name: PASSPORT_PUBLIC_KEY_PATH
           value: "{{ include "secretsPath" . }}/{{ .Values.global.elixir.pubKey }}"
+      {{- end }}
         - name: KEYSTORE_PATH
           value: "/etc/ssl/certs/java/doa.p12"
         - name: KEYSTORE_PASSWORD
@@ -92,7 +98,7 @@ spec:
           value: "{{ template "c4ghPath" . }}/passphrase"
         ports:
         - name: doa
-          containerPort: {{ .Values.doa.port }}
+          containerPort: 8080
           protocol: TCP
         livenessProbe:
           tcpSocket:
@@ -110,8 +116,10 @@ spec:
         - name: tls-certs
           mountPath: "/etc/ssl/certs/java"
       {{- if not .Values.global.confFile }}
+      {{- if .Values.global.elixir.pubKey }}
         - name: jwt-token
           mountPath: {{ include "secretsPath" . }}
+      {{- end }}
         - name: c4gh-key
           mountPath: {{ template "c4ghPath" . }}
       {{- end }}
@@ -125,6 +133,7 @@ spec:
             secretName: {{ template "sda.fullname" . }}-doa-certs
             defaultMode: 0440
       {{- if not .Values.global.confFile }}
+      {{- if .Values.global.elixir.pubKey }}
         - name: jwt-token
           projected:
             defaultMode: 0440
@@ -134,6 +143,7 @@ spec:
                 items:
                   - key: {{ .Values.global.elixir.pubKey }}
                     path: {{ .Values.global.elixir.pubKey }}
+      {{- end }}
         - name: c4gh-key
           secret:
             secretName: {{ template "sda.fullname" . }}-c4gh

--- a/sda-svc/templates/doa-service.yaml
+++ b/sda-svc/templates/doa-service.yaml
@@ -8,12 +8,8 @@ metadata:
 spec:
   ports:
   - name: doa
-    port: {{ .Values.doa.servicePort }}
+    port: {{ .Values.global.doa.servicePort }}
     targetPort: doa
-    protocol: TCP
-  - name: debug
-    port: {{ .Values.doa.debugPort }}
-    targetPort: {{ .Values.doa.debugPort }}
     protocol: TCP
   selector:
     app: {{ template "sda.fullname" . }}-doa

--- a/sda-svc/templates/finalize-deploy.yaml
+++ b/sda-svc/templates/finalize-deploy.yaml
@@ -58,9 +58,9 @@ spec:
         - name: BROKER_KEYFILE
           value:  "{{ template "tlsPath" . }}/finalize.key"
         - name: BROKER_VERIFY_HOSTNAME
-          value: {{ .Values.global.broker.verifyHostname | quote }}
+          value: "false"
         - name: BROKER_VERIFY_PEER
-          value:  "yes"
+          value: {{ .Values.global.broker.verifyPeer | quote }}
         {{- if not .Values.global.confFile }}
         - name: BROKER_CONNECTION
           valueFrom:

--- a/sda-svc/templates/ingest-deploy.yaml
+++ b/sda-svc/templates/ingest-deploy.yaml
@@ -74,9 +74,9 @@ spec:
         - name: BROKER_KEYFILE
           value: "{{ template "tlsPath" . }}/ingest.key"
         - name: BROKER_VERIFY_HOSTNAME
-          value: {{ .Values.global.broker.verifyHostname | quote }}
+          value: "false"
         - name: BROKER_VERIFY_PEER
-          value: "yes"
+          value: {{ .Values.global.broker.verifyPeer | quote }}
         - name: INBOX_STORAGE_DRIVER
       {{- if eq "S3Storage" .Values.global.inbox.storageType }}
           value: S3Storage

--- a/sda-svc/templates/sftp-inbox-deploy.yaml
+++ b/sda-svc/templates/sftp-inbox-deploy.yaml
@@ -72,8 +72,6 @@ spec:
           value: {{ include "mqUserInbox" . | quote }}
         - name: BROKER_VHOST
           value: {{ include "brokerVhost" . | quote }}
-        - name: INBOX_PORT
-          value: "8080"
         - name: CEGA_ENDPOINT
           value: {{ printf "%s%s" (.Values.global.cega.host) "/lega/v1/legas/users/%s?idType=username" | quote }}
         - name: CEGA_ENDPOINT_CREDS
@@ -91,18 +89,18 @@ spec:
           value: "true"
         ports:
         - name: inbox
-          containerPort: 8080
+          containerPort: 2222
           protocol: TCP
         livenessProbe:
           tcpSocket:
-            port: 8080
+            port: 2222
           initialDelaySeconds: 120
-          periodSeconds: 30
+          periodSeconds: 5
         readinessProbe:
           tcpSocket:
-            port: 8080
+            port: 2222
           initialDelaySeconds: 30
-          periodSeconds: 1
+          periodSeconds: 5
         volumeMounts:
         - name: inbox
           mountPath: "/ega/inbox"

--- a/sda-svc/templates/sftp-inbox-deploy.yaml
+++ b/sda-svc/templates/sftp-inbox-deploy.yaml
@@ -73,7 +73,7 @@ spec:
         - name: BROKER_VHOST
           value: {{ include "brokerVhost" . | quote }}
         - name: INBOX_PORT
-          value: {{ .Values.sftpInbox.port | quote }}
+          value: "8080"
         - name: CEGA_ENDPOINT
           value: {{ printf "%s%s" (.Values.global.cega.host) "/lega/v1/legas/users/%s?idType=username" | quote }}
         - name: CEGA_ENDPOINT_CREDS
@@ -91,7 +91,7 @@ spec:
           value: "true"
         ports:
         - name: inbox
-          containerPort: {{ .Values.sftpInbox.port }}
+          containerPort: 8080
           protocol: TCP
         livenessProbe:
           tcpSocket:

--- a/sda-svc/templates/sftp-inbox-deploy.yaml
+++ b/sda-svc/templates/sftp-inbox-deploy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "sda.fullname" . }}-inbox
   labels:
     role: inbox
-    app: {{ template "sda.name" . }}
+    app: {{ template "sda.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: {{ .Release.Name }}-inbox
     release: {{ .Release.Name }}
@@ -16,15 +16,15 @@ spec:
   revisionHistoryLimit: {{ default "3" .Values.global.revisionHistory }}
   selector:
     matchLabels:
-      app: {{ template "sda.name" . }}-inbox
+      app: {{ template "sda.fullname" . }}-inbox
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "sda.name" . }}-inbox
+        app: {{ template "sda.fullname" . }}-inbox
         role: inbox
         release: {{ .Release.Name }}
-        type: sft-inbox
+        type: sftp-inbox
       annotations:
         {{- if not .Values.global.confFile }}
         checksum/config: {{ include (print $.Template.BasePath "/sftp-inbox-secrets.yaml") . | sha256sum }}

--- a/sda-svc/templates/verify-deploy.yaml
+++ b/sda-svc/templates/verify-deploy.yaml
@@ -74,9 +74,9 @@ spec:
         - name: BROKER_KEYFILE
           value:  "{{ template "tlsPath" . }}/verify.key"
         - name: BROKER_VERIFY_HOSTNAME
-          value: {{ .Values.global.broker.verifyHostname | quote }}
+          value: "false"
         - name: BROKER_VERIFY_PEER
-          value:  "yes"
+          value: {{ .Values.global.broker.verifyPeer | quote }}
         {{- if not .Values.global.confFile }}
         - name: C4GH_FILE_FILEPATH
           value: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.file }}"

--- a/sda-svc/values.yaml
+++ b/sda-svc/values.yaml
@@ -120,6 +120,9 @@ global:
     port: 5432
     sslMode: "verify-full"
 
+  doa:
+    servicePort: 443
+
   elixir:
     pubKey: ""
 
@@ -178,8 +181,6 @@ doa:
     limits:
       memory: "1024Mi"
       cpu: "2000m"
-  port: 8080
-  servicePort: 443
   debugPort: 1234
   logpath: "/tmp/logs"
   keystorePass: "changeit"

--- a/sda-svc/values.yaml
+++ b/sda-svc/values.yaml
@@ -124,16 +124,8 @@ global:
     pubKey: ""
 
   inbox:
-    brokerRoutingKey: "files.inbox"
     servicePort: 9000
-    storageType: "S3Storage" # S3Storage or FileStorage
-  # The six lines below is only used with S3 backend
-    s3Url: ""
-    s3Bucket: ""
-    s3Region: "us-east-1"
-    s3ChunkSize: 15 # Chunk size in MB > 5
-    s3AccessKey: ""
-    s3SecretKey: ""
+    storageType: "FileStorage"
   # These lines below are only used with FileStorage
     path: "/ega/inbox"
     user: "lega"

--- a/sda-svc/values.yaml
+++ b/sda-svc/values.yaml
@@ -18,7 +18,7 @@ global:
 
 # Deployment can be split into `external` and `internal` components
 # by setting deploymentType to the desired type
-# if left undefined (default) or `all`, all services are deployed.
+# if left undefined or `all`, all services are deployed.
   deploymentType: "all"
 
   ingress:
@@ -96,7 +96,7 @@ global:
     host: ""
     exchange: ""
     port: 5671
-    verifyHostname: false
+    verifyPeer: true
     vhost: "/"
 # This 
     password: ""
@@ -118,7 +118,7 @@ global:
     passIngest: ""
     passOutgest: ""
     port: 5432
-    sslMode: "verify-ca"
+    sslMode: "verify-full"
 
   elixir:
     pubKey: ""
@@ -179,7 +179,7 @@ doa:
       memory: "1024Mi"
       cpu: "2000m"
   port: 8080
-  servicePort: 8080
+  servicePort: 443
   debugPort: 1234
   logpath: "/tmp/logs"
   keystorePass: "changeit"
@@ -237,8 +237,6 @@ s3Inbox:
     limits:
       memory: "1024Mi"
       cpu: "1000m"
-  port: 8000
-  servicePort: 8000
 # Extra annotations to attach to the service pods
 # This should be a multi-line string mapping directly to the a map of
 # the annotations to apply to the service pods
@@ -257,8 +255,6 @@ sftpInbox:
     limits:
       memory: "256Mi"
       cpu: "250m"
-  port: 9000
-  servicePort: 9000
   keystorePass: "changeit"
   nodeHostname: ""
 # Extra annotations to attach to the pod

--- a/sda-svc/values.yaml
+++ b/sda-svc/values.yaml
@@ -127,7 +127,7 @@ global:
     pubKey: ""
 
   inbox:
-    servicePort: 9000
+    servicePort: 2222
     storageType: "FileStorage"
   # These lines below are only used with FileStorage
     path: "/ega/inbox"


### PR DESCRIPTION
This adds a top level README and a REDAME in sda-svc

Further more it removes some unnecessary configuration options together with some deployment relates issues where the services did not connect to the endpoints due to inconsistent use if `name` vs `fullname` labeling of the pods.