### PR TITLE
Fix typo networkpolicy sda-svc

### DIFF
--- a/sda-svc/templates/networkpolicy.yaml
+++ b/sda-svc/templates/networkpolicy.yaml
@@ -51,7 +51,7 @@ spec:
         matchLabels:
           role: broker
     ports:
-    - protocol: tcp
+    - protocol: TCP
       port: 5432
     {{- if .Values.global.networkPolicy.databaseNamespace }}
     - namespaceSelector:
@@ -62,7 +62,7 @@ spec:
         matchLabels:
           role: database
     ports:
-    - protocol: tcp
+    - protocol: TCP
       port: 5432
 ---
 {{- end }}


### PR DESCRIPTION
Caused applying network policies for verify to fail.