### PR TITLE
Allow body size of 100Mib in S3proxy ingress

### DIFF
--- a/sda-svc/templates/s3-inbox-ingress.yaml
+++ b/sda-svc/templates/s3-inbox-ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: "/"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
     {{- if .Values.global.ingress.issuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.ingress.issuer | quote }}
     {{- end }}


### PR DESCRIPTION
NGINX defaults to 1 MiB payload and we need way more that that.
This sets the allowed payload to 100 MiB which should be more than enough as the default multipart upload chunksize is 15 MiB in most S3 clients.