### PR TITLE
Disable failure for the job publishing charts

### DIFF
--- a/.github/workflows/publish_charts.yml
+++ b/.github/workflows/publish_charts.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
For aesthetical reasons, ignore failures because of merges to master
without version changes.

This changes so the action run after merge is not considered failed,
even if the charts version published already exist.