### PR TITLE
Changes needed to support newer versions

### DIFF
--- a/sda-db/templates/podsecuritypolicy.yaml
+++ b/sda-db/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbacEnabled .Values.securityPolicy.create }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Release.Name }}

--- a/sda-mq/templates/podsecuritypolicy.yaml
+++ b/sda-mq/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbacEnabled .Values.securityPolicy.create }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Release.Name }}


### PR DESCRIPTION
Changes needed for running with helm 3.3.0/microk8s (v1.18.6).

The charts seems to still work with k3s 0.10.0 (v1.16.2-k3s.1). I can't find any reasonably easy way to test with older version.