### PR TITLE
rename orchestrator to have similiar name as other sda-svc

### DIFF
--- a/.github/ci_tests/svc.conf
+++ b/.github/ci_tests/svc.conf
@@ -14,5 +14,5 @@
     {"name":"db", "dns": "postgres-sda-db", "ns": "default"},
     {"name":"doa", "ns": "default"},
     {"name":"tester", "ns": "default"},
-    {"name":"orchestrator", "ns": "default"}
+    {"name":"orchestrate", "ns": "default"}
  ]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
         do echo "waiting for database to become ready";
         RETRY_TIMES=$((RETRY_TIMES+1));
         if [ $RETRY_TIMES -eq 10 ]; then exit 1; fi
-        sleep 3;
+        sleep 10;
         done
     - name: debug DB
       if: failure()
@@ -223,7 +223,7 @@ jobs:
         do echo "waiting for database to become ready";
         RETRY_TIMES=$((RETRY_TIMES+1));
         if [ $RETRY_TIMES -eq 10 ]; then exit 1; fi
-        sleep 3;
+        sleep 10;
         done
     - name: debug DB
       if: failure()
@@ -430,7 +430,7 @@ jobs:
         do echo "waiting for database to become ready";
         RETRY_TIMES=$((RETRY_TIMES+1));
         if [ $RETRY_TIMES -eq 10 ]; then exit 1; fi
-        sleep 3;
+        sleep 10;
         done
     - name: debug DB
       if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -468,8 +468,8 @@ jobs:
     - name: Prepare for deployment
       run: |
         cp LocalEGA-deploy-init/config/certs/root.ca.crt sda-orch/files/ca.crt
-        cp LocalEGA-deploy-init/config/certs/orchestrator.ca.crt sda-orch/files/orch.crt
-        cp LocalEGA-deploy-init/config/certs/orchestrator.ca.key sda-orch/files/orch.key
+        cp LocalEGA-deploy-init/config/certs/orchestrate.ca.crt sda-orch/files/orch.crt
+        cp LocalEGA-deploy-init/config/certs/orchestrate.ca.key sda-orch/files/orch.key
     - name: Deploy the SDA orch
       run: |
         DB_IN_PASS=$(grep pg_in_password LocalEGA-deploy-init/config/trace.yml | awk {'print $2'} | sed --expression 's/\"//g')
@@ -492,8 +492,8 @@ jobs:
     - name: Wait for SDA Orch to become ready
       run: |
         RETRY_TIMES=0
-        until kubectl get pods -lrole=orchestrator -o jsonpath='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep "Ready=True";
-        do echo "waiting for orchestrator to become ready";
+        until kubectl get pods -lrole=orchestrate -o jsonpath='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status}' | grep "Ready=True";
+        do echo "waiting for orchestrate to become ready";
         RETRY_TIMES=$((RETRY_TIMES+1));
         if [ $RETRY_TIMES -eq 10 ]; then exit 1; fi
         sleep 10;
@@ -501,8 +501,8 @@ jobs:
     - name: debug sda orch
       if: failure()
       run: |
-        kubectl describe pod -l role=orchestrator
+        kubectl describe pod -l role=orchestrate
     - name: log sda orch
       if: failure()
       run: |
-        kubectl logs $(kubectl get pods | grep orchestrator | awk '{print $1}')
+        kubectl logs $(kubectl get pods | grep orchestrate | awk '{print $1}')

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ This chart deploys the service components needed for the Sensitive Data Archive 
 
 ## sda-orch
 
-This chart deploys the orchestrator service needed for the Sensitive Data Archive standalone solution (No European Genome Archive connection).
+This chart deploys the orchestrate service needed for the Sensitive Data Archive standalone solution (No European Genome Archive connection).

--- a/sda-orch/Chart.yaml
+++ b/sda-orch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sda-orch
-version: "0.1"
-description: Orchestrator component for Sensitive Data Archive (SDA) standalone installation
+version: "0.2"
+description: Orchestrate component for Sensitive Data Archive (SDA) standalone installation
 home: https://neic-sda.readthedocs.io
 icon: https://neic.no/assets/images/logo.png
 sources:

--- a/sda-orch/README.md
+++ b/sda-orch/README.md
@@ -1,4 +1,4 @@
-# SDA Orchestrator Service
+# SDA Orchestrate Service
 
 ## Installing the Chart
 

--- a/sda-orch/templates/deployment.yaml
+++ b/sda-orch/templates/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "sda.fullname" . }}-orchestrator
+  name: {{ template "sda.fullname" . }}-orchestrate
   labels:
-    role: orchestrator
+    role: orchestrate
     app: {{ template "sda.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: {{ .Release.Name }}-orchestrator
+    component: {{ .Release.Name }}-orchestrate
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -14,13 +14,13 @@ spec:
   revisionHistoryLimit: {{ default "3" .Values.revisionHistory }}
   selector:
     matchLabels:
-      app: {{ template "sda.name" . }}-orchestrator
+      app: {{ template "sda.name" . }}-orchestrate
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "sda.name" . }}-orchestrator
-        role: orchestrator
+        app: {{ template "sda.name" . }}-orchestrate
+        role: orchestrate
         release: {{ .Release.Name }}
       annotations:
         {{- if not .Values.secretsService }}
@@ -52,7 +52,7 @@ spec:
           mountPath: /tls
     {{- end }}
       containers:
-      - name: orchestrator
+      - name: orchestrate
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
         securityContext:


### PR DESCRIPTION
As #42 we should keep name of sda-svc in sync
Charts time out with 30 sec wait time for db.