### PR TITLE
fix sftp inbox probes

### DIFF
--- a/sda-svc/Chart.yaml
+++ b/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: "0.5"
+version: "0.6"
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io
 icon: https://neic.no/assets/images/logo.png

--- a/sda-svc/templates/sftp-inbox-deploy.yaml
+++ b/sda-svc/templates/sftp-inbox-deploy.yaml
@@ -103,7 +103,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - netstat -an | grep -q :2222
+            - netstat -an | grep -q ':2222 '
           initialDelaySeconds: 120
           periodSeconds: 5
         readinessProbe:
@@ -111,7 +111,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - netstat -an | grep -q :2222
+            - netstat -an | grep -q ':2222 '
           initialDelaySeconds: 30
           periodSeconds: 5
         volumeMounts:

--- a/sda-svc/templates/sftp-inbox-deploy.yaml
+++ b/sda-svc/templates/sftp-inbox-deploy.yaml
@@ -101,17 +101,17 @@ spec:
         livenessProbe:
           exec:
             command:
-            - lsof
-            - -tni
-            - :2222
+            - /bin/sh
+            - -c
+            - netstat -an | grep -q :2222
           initialDelaySeconds: 120
           periodSeconds: 5
         readinessProbe:
           exec:
             command:
-            - lsof
-            - -tni
-            - :2222
+            - /bin/sh
+            - -c
+            - netstat -an | grep -q :2222
           initialDelaySeconds: 30
           periodSeconds: 5
         volumeMounts:

--- a/sda-svc/templates/sftp-inbox-deploy.yaml
+++ b/sda-svc/templates/sftp-inbox-deploy.yaml
@@ -99,13 +99,19 @@ spec:
           containerPort: 2222
           protocol: TCP
         livenessProbe:
-          tcpSocket:
-            port: 2222
+          exec:
+            command:
+            - lsof
+            - -tni
+            - :2222
           initialDelaySeconds: 120
           periodSeconds: 5
         readinessProbe:
-          tcpSocket:
-            port: 2222
+          exec:
+            command:
+            - lsof
+            - -tni
+            - :2222
           initialDelaySeconds: 30
           periodSeconds: 5
         volumeMounts:


### PR DESCRIPTION
- current probles cause `SSH2_DISCONNECT_PROTOCOL_ERROR`
- `lsof` does not need to open a connection

example of the warning
```
2020-10-21 18:08:42.433  WARN 1 --- [)-nio2-thread-1] o.a.s.server.session.ServerSessionImpl   : disconnect(ServerSessionImpl[null@/10.0.0.7:54854]) operation failed (IOException) for reason=SSH2_DISCONNECT_PROTOCOL_ERROR [Detected AuthTimeout after 120086/120000 ms.]: Broken pipe
2020-10-21 18:08:44.430  INFO 1 --- [-timer-thread-1] o.a.s.server.session.ServerSessionImpl   : Disconnecting(ServerSessionImpl[null@/10.0.0.7:54868]): SSH2_DISCONNECT_PROTOCOL_ERROR - Detected AuthTimeout after 120442/120000 ms.
```

