### PR TITLE
duplicate name for volume mount

### DIFF
--- a/sda-svc/templates/backup-deploy.yaml
+++ b/sda-svc/templates/backup-deploy.yaml
@@ -220,7 +220,7 @@ spec:
           mountPath: {{ .Values.global.archive.volumePath | quote }}
   {{- end }}
   {{- if eq "posix" .Values.global.backupArchive.storageType }}
-        - name: archive
+        - name: backup
           mountPath: {{ .Values.global.backupArchive.volumePath | quote }}
   {{- end }}
   {{- if not .Values.global.pkiService }}


### PR DESCRIPTION
cause backup to get confused and overwrite file in archive, becoming `0` in file size