### PR TITLE
Use less inconsistent name for CA

### DIFF
--- a/dev_tools/scripts/svc-setup.sh
+++ b/dev_tools/scripts/svc-setup.sh
@@ -11,7 +11,7 @@ cp sda-deploy-init/config/certs/orchestrate.ca.crt sda-orch/files/orch.crt
 cp sda-deploy-init/config/certs/orchestrate.ca.key sda-orch/files/orch.key
 
 ## sda-db certs
-cp sda-deploy-init/config/certs/root.ca.crt sda-db/files/CA.crt
+cp sda-deploy-init/config/certs/root.ca.crt sda-db/files/ca.crt
 cp sda-deploy-init/config/certs/db.ca.crt sda-db/files/pg.crt
 cp sda-deploy-init/config/certs/db.ca.key sda-db/files/pg.key
 

--- a/sda-db/README.md
+++ b/sda-db/README.md
@@ -40,7 +40,7 @@ Parameter | Description | Default
 
 Certificates should be placed in the `files` folder and named accordingly.
 
-- CA.crt, root ca certificate.
+- ca.crt, root ca certificate.
 - pg.crt, serer certificate.
 - pg.key, server key.
 

--- a/sda-db/files/README.md
+++ b/sda-db/files/README.md
@@ -2,6 +2,6 @@
 
 This folder should contain the servers TLS certificates and optionally a root ca certificate if client validation is to be activated.
 
-- CA.crt, root ca certificate.
+- ca.crt, root ca certificate.
 - pg.crt, serer certificate.
 - pg.key, server key.

--- a/sda-db/templates/release-test-deploy.yaml
+++ b/sda-db/templates/release-test-deploy.yaml
@@ -54,7 +54,7 @@ spec:
            s=${PKI_VOLUME_PATH:-/certs};
            cp "$s/tester.ca.key" $PGSSL/postgresql.key;
            cp "$s/tester.ca.crt" $PGSSL/postgresql.crt;
-           cp "$s/CA.crt" $PGSSL/root.crt;
+           cp "$s/ca.crt" $PGSSL/root.crt;
            chmod -R og-rw $PGSSL;
            count=1;
            until (psql -h ${DB_HOST} -U lega_in lega -c "select * from local_ega.dbschema_version" || [ "$count" -ge 10 ]); do 
@@ -74,8 +74,8 @@ spec:
                 path: tester.ca.key
               - key: tester.ca.crt
                 path: tester.ca.crt
-              - key: CA.crt
-                path: CA.crt
+              - key: ca.crt
+                path: ca.crt
     {{- end }}
   restartPolicy: Never
 

--- a/sda-db/templates/secrets.yaml
+++ b/sda-db/templates/secrets.yaml
@@ -6,12 +6,12 @@ data:
   pgInPasswd: {{ include "pgInPassword" . | b64enc }}
   pgOutPasswd: {{ include "pgOutPassword" . | b64enc }}
 {{- if not .Values.externalPkiService.tlsPath }}
-{{- $mqcerts := .Files.Glob "files/pg.*" }}
-{{- $cacert := .Files.Glob "files/CA.crt" }}
+{{- $dbcerts := .Files.Glob "files/pg.*" }}
+{{- $cacert := .Files.Glob "files/ca.crt" }}
 {{- if $cacert }}
 {{ ( $cacert).AsSecrets | indent 2 }}
 {{- end  }}
-{{- if $mqcerts }}
-{{ ( $mqcerts ).AsSecrets | indent 2 }}
+{{- if $dbcerts }}
+{{ ( $dbcerts ).AsSecrets | indent 2 }}
 {{- end }}
 {{- end }}

--- a/sda-db/templates/statefulset.yaml
+++ b/sda-db/templates/statefulset.yaml
@@ -86,7 +86,7 @@ spec:
           value: {{ .Values.persistence.mountPath }}/tls/pg.key
         {{- if .Values.global.verifyPeer }}
         - name: PG_CA
-          value: {{ .Values.persistence.mountPath }}/tls/CA.crt
+          value: {{ .Values.persistence.mountPath }}/tls/ca.crt
         - name: PG_VERIFY_PEER
           value: {{ ternary 1 0 (.Values.global.verifyPeer) | quote }}
         {{- end }}
@@ -135,8 +135,8 @@ spec:
               name: {{ template "sda.fullname" . }}
               items:
               {{- if .Values.global.verifyPeer }}
-              - key: CA.crt
-                path: CA.crt
+              - key: ca.crt
+                path: ca.crt
               {{- end }}
               - key: pg.crt
                 path: pg.crt


### PR DESCRIPTION
CA cert is ca.crt in other services, use that for sda-db as well.