### PR TITLE
missing db port for sda-doa

### DIFF
--- a/sda-svc/Chart.yaml
+++ b/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: "0.11"
+version: "0.12"
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io
 icon: https://neic.no/assets/images/logo.png

--- a/sda-svc/templates/doa-deploy.yaml
+++ b/sda-svc/templates/doa-deploy.yaml
@@ -81,6 +81,8 @@ spec:
       {{- end }}
         - name: DB_INSTANCE
           value: {{ required "A valid database host is required" .Values.global.db.host | quote}}
+        - name: DB_PORT
+          value: {{ .Values.global.db.port | quote }}
         - name: POSTGRES_DB
           value: {{ required "A database name is required" .Values.global.db.name | quote }}
         - name: SSL_MODE


### PR DESCRIPTION
- added missing db-port for sda-doa
- bump version to `0.12`