### PR TITLE
[sda-svc][auth] Remove path from CEGA_AUTHURL

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: "0.14.1"
+version: "0.14.2"
 kubeVersion: ">= 1.19.0"
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -79,7 +79,7 @@ Parameter | Description | Default
 `global.broker.password` | Shared password to the message broker. |`/`
 `global.broker.username` | Shared user to the message broker. |`/`
 `global.broker.backupRoutingKey` | routing key used to send messages to backup service |`""`
-`global.cega.host` | Domain name for the EGA user authentication service. |`""`
+`global.cega.host` | Full URI to the EGA user authentication service. |`""`
 `global.cega.user` | Username for the EGA user authentication service. |`""`
 `global.cega.password` | Password for the EGA user authentication service. |`""`
 `global.c4gh.file` | Private C4GH key. |`c4gh.key`

--- a/charts/sda-svc/templates/auth-deploy.yaml
+++ b/charts/sda-svc/templates/auth-deploy.yaml
@@ -91,7 +91,7 @@ spec:
         - name: CEGA_JWTISSUER
           value: "https://{{ .Values.global.ingress.hostName.auth }}"
         - name: CEGA_AUTHURL
-          value: {{ printf "%s%s" (.Values.global.cega.host) "/lega/v1/legas/users/" | quote }}
+          value: {{ .Values.global.cega.host | quote }}
         - name: CEGA_JWTPRIVATEKEY
           value: "{{ template "secretsPath" . }}/{{ .Values.global.auth.jwtKey }}"
         - name: CEGA_JWTSIGNATUREALG


### PR DESCRIPTION
We set the entire path to the NSS endpoint at CRG, that way it is easier to keep up with any changes on their side.

Fixes: #95 