### PR TITLE
Chart changes [ Orchestrator ] [ part 3 of 4 ]

### DIFF
--- a/.github/ci_tests/lint_helper.sh
+++ b/.github/ci_tests/lint_helper.sh
@@ -5,12 +5,6 @@ set -e
 
 pushd charts
 
-if [ $1 = "sda-orch" ]; then
-touch $1/files/ca.crt
-touch $1/files/orch.crt
-touch $1/files/orch.key
-fi
-
 if [ $1 = "sda-svc" ]; then
 for n in ca backup doa finalize inbox ingest intercept verify mapper
 do

--- a/charts/sda-orch/Chart.yaml
+++ b/charts/sda-orch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-orch
-version: "0.6.2"
+version: "0.7.0"
 description: Orchestrate component for Sensitive Data Archive (SDA) standalone installation
 home: https://neic-sda.readthedocs.io
 icon: https://neic.no/assets/images/logo.png

--- a/charts/sda-orch/README.md
+++ b/charts/sda-orch/README.md
@@ -12,17 +12,21 @@ Parameter | Description | Default
 `image.tag` | sda-orch  container image version | `"latest"`
 `image.pullPolicy` | sda-orch container image pull policy | `Always`
 `logLevel` | sda-orch logging level | `info`
-`global.tlsPath` | Default TLS path for certs and key in the pod. | `/tls/certs`
 `revisionHistory` | Number of revisions to keep for the option to rollback a deployment | `3`
 `podAnnotations` | Annotations applied to pods of all services. |`{}`
-`pkiService` | If an external PKI infrastructure is used set this to true. |`false`
-`pkiPermissions` | if permissions needs to be set on the injected certificates set this to true | `true`
+`pkiService.enabled` | If an external PKI infrastructure is used set this to true. |`false`
+`pkiService.tlsPath` | The path where the certifiates are placed. | `""`
+`tls.enabled` | Enable SSL for MQ | `true`
+`tls.secretName` | Name of the secret that holds the certificates | `""`
+`tls.permissions` | if permissions needs to be set on the injected certificates set this to true | `true`
+`tls.cert` | Name of the client certificate file | `""`
+`tls.key` | Name of the client key file | `""`
+`tls.caCert` | name of the CA file| `""`
 `rbacEnabled` | Use role based access control. |`true`
 `networkPolicy.create` | Use network isolation. | `false`
 `podSecurityPolicy.create` | Use pod security policy. | `false`
-`vaultSecrets` | Use If Hasicort Vault is used for secrets management. | `false`
-`sslmode.ssl` | Enable SSL for MQ | `true`
-`sslmode.verifyPeer` | Use Client/Server verification (used by MQ connection). | `true`
+`vaultSecrets` | Use If Hasicorp Vault is used for secrets management. | `false`
+`broker.verifyPeer` | Use Client/Server verification (used by MQ connection). | `true`
 `broker.host` | Domain name or IP address to the message broker. |`""`
 `broker.exchange` | Exchange to publish messages to. |`""`
 `broker.port` | Port for the message broker. |`5671`
@@ -47,8 +51,11 @@ Parameter | Description | Default
 
 ### TLS
 
-Certificates should be placed in the `files` folder and named accordingly.
+Create a secret that contains the certificates
 
-- ca.crt, root ca certificate.
-- orch.crt, serer certificate.
-- orch.key, server key.
+```cmd
+kubectl create secret generic orch-certs \
+--from-file=ca.crt \
+--from-file=orch.crt \
+--from-file=orch.key
+```

--- a/charts/sda-orch/files/README.md
+++ b/charts/sda-orch/files/README.md
@@ -1,9 +1,0 @@
-# Folder contents
-
-This folder should contain the TLS certificates for orchestartor service and the root ca certificate.
-
-- ca.crt, root ca certificate.
-- orch.crt, service certificate.
-- orch.key, service key.
-
-If `useCustomConfig` is enabled it expects a file with the name `config.json` so that it can load it as configuration from it. [Config file example](https://github.com/neicnordic/sda-orchestration/blob/master/sda_orchestrator/config/config.json) .

--- a/charts/sda-orch/templates/_helpers.yaml
+++ b/charts/sda-orch/templates/_helpers.yaml
@@ -31,10 +31,38 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "tlsPath" -}}
-{{- ternary "/tls/certs" .Values.tlsPath (empty .Values.tlsPath) -}}
+    {{- if .Values.pkiService.enabled }}
+        {{- printf "%s" (regexReplaceAll "/$"  (required "pkiService.tlsPath is required if pkiservice is enabled" .Values.pkiService.tlsPath) "" ) -}}
+    {{- else }}
+        {{- printf "/tls/certs" }}
+    {{- end -}}    
 {{- end -}}
 
 {{/**/}}
 {{- define "mqPass" -}}
 {{- .Values.broker.password -}}
+{{- end -}}
+
+{{- define "orchCert" -}}
+    {{- if .Values.pkiService.enabled }}
+        {{- printf "%s" (regexReplaceAll "^/*|/+" (printf "%s/%s" .Values.pkiService.tlsPath (required "a TLS certificate is required" .Values.tls.cert)) "/")}}
+    {{- else }}
+        {{- printf "/tls/certs/%s" (required "a TLS certificate is required" .Values.tls.cert)}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "orchKey" -}}
+    {{- if .Values.pkiService.enabled }}
+        {{- printf "%s" (regexReplaceAll "^/*|/+" (printf "%s/%s" .Values.pkiService.tlsPath (required "a TLS key is required" .Values.tls.key)) "/")}}
+    {{- else }}
+        {{- printf "/tls/certs/%s" (required "a TLS key is required" .Values.tls.key)}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "caCert" -}}
+    {{- if .Values.pkiService.enabled }}
+        {{- printf "%s" (regexReplaceAll "^/*|/+" (printf "%s/%s" .Values.pkiService.tlsPath (required "a CA certificate is required" .Values.tls.caCert)) "/")}}
+    {{- else }}
+        {{- printf "/tls/certs/%s" (required "a CA certificate is required" .Values.tls.caCert) }}
+    {{- end -}}
 {{- end -}}

--- a/charts/sda-orch/templates/deployment.yaml
+++ b/charts/sda-orch/templates/deployment.yaml
@@ -37,12 +37,12 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-    {{- if .Values.pkiPermissions }}
+    {{- if .Values.tls.permissions }}
       initContainers:
       - name: tls-init
         image: busybox
         command: ["/bin/sh", "-c"]
-        args: ["/bin/cp /tls-certs/* /tls/ && chown 1000:1000 /tls/* && chmod 0400 /tls/*"]
+        args: ["/bin/cp {{ include "tlsPath" . }}/* /tls/ && chown 1000:1000 /tls/* && chmod 0400 /tls/*"]
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
@@ -121,20 +121,25 @@ spec:
           value: /config/config.json
         {{- end }}
       {{- end }}
-        {{- if .Values.sslmode.ssl }}
+      {{- if .Values.tls.enabled}}
+        - name: BROKER_SSL
+          value: "true"
         - name: SSL_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-        {{- if .Values.sslmode.verifyPeer }}
+          value: {{ include "caCert" . | quote }}
+        {{- if .Values.broker.verifyPeer }}
         - name: SSL_CLIENTCERT
-          value: {{ include "tlsPath" . }}/orch.crt
+          value: {{ include "orchCert" . | quote }}
         - name: SSL_CLIENTKEY
-          value: {{ include "tlsPath" . }}/orch.key
+          value: {{ include "orchKey" . | quote }}
         {{- end }}
+      {{- else }}
+        - name: BROKER_SSL
+          value: "false"
       {{- end }}
         resources:
 {{ toYaml .Values.resources | trim | indent 10 }}
         volumeMounts:
-        {{- if not .Values.pkiService }}
+        {{- if and .Values.tls.enabled (not .Values.pkiService.enabled) }}
         - name: tls
           mountPath: {{ template "tlsPath" . }}
         {{- end }}
@@ -147,12 +152,12 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
-    {{- if not .Values.pkiService }}
-      - name: {{ ternary "tls" "tls-certs" (empty .Values.pkiPermissions) }}
+    {{- if and .Values.tls.enabled (not .Values.pkiService.enabled) }}
+      - name: {{ ternary "tls" "tls-certs" (empty .Values.tls.permissions) }}
         secret:
           defaultMode: 0440
-          secretName: {{ template "sda.fullname" . }}-orchestrate-certs
-      {{- if .Values.pkiPermissions }}
+          secretName: {{ required "A tls secret is required " .Values.tls.secretName }}
+      {{- if .Values.tls.permissions }}
       - name: tls
         emptyDir:
           medium: Memory

--- a/charts/sda-orch/templates/secrets.yaml
+++ b/charts/sda-orch/templates/secrets.yaml
@@ -12,14 +12,3 @@ data:
   remsKey: {{ required "REMS API key missing" .Values.datasetID.rems.key | b64enc }}
   {{- end }}
 {{- end }}
-{{- if not .Values.pkiService }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "sda.fullname" . }}-orchestrate-certs
-data:
-{{ ( .Files.Glob "files/ca.crt" ).AsSecrets | trim | indent 2 }}
-{{ ( .Files.Glob "files/orch.crt" ).AsSecrets | trim | indent 2 }}
-{{ ( .Files.Glob "files/orch.key" ).AsSecrets | trim | indent 2 }}
-{{- end }}

--- a/charts/sda-orch/values.yaml
+++ b/charts/sda-orch/values.yaml
@@ -15,10 +15,10 @@ logLevel: "info"
 # the annotations to apply to the service pods
 podAnnotations: {}
 
-# If an external PKI infrastructure is used set this to true
-pkiService: false
-# if permissions needs to be set on the injected certificates set this to true
-pkiPermissions: true
+# If an external PKI infrastructure is used set enabled to true
+pkiService: 
+  enabled: false
+  tlsPath: ""
 
 # Assume RBAC is enabled in the cluster
 rbacEnabled: true
@@ -34,7 +34,13 @@ networkPolicy:
   create: false
   brokerNamespace: ""
 
-tlsPath: "/tls/certs"
+tls:
+  enabled: true
+  secretName:
+  permissions: false
+  cert:
+  key:
+  caCert:
 
 ## RevisionHistory
 ##  If defined, set the revisionHistoryLimit of the deployment, defaults to 3
@@ -48,10 +54,6 @@ vaultSecrets: false
 envFile: "env"
 
 # used by Message Broker
-sslmode:
-  ssl: true
-  verifyPeer: true
-
 broker:
   exchange: ""
   host: ""
@@ -66,6 +68,7 @@ broker:
     accessionids: "accessionIDs"
     ingest: "ingest"
     mappings: "mappings"
+  verifyPeer: true
 
 # Datacite and REMS depend on one another
 # if we set one the other one needs to be configured

--- a/dev_tools/config/orch.yaml
+++ b/dev_tools/config/orch.yaml
@@ -1,9 +1,3 @@
-global:
-  c4ghPath: c4gh
-  jwtPath: jwt
-  tlsPath: tls
-  podSecurityPolicy:
-    create: false
 broker:
   vhost: "sda"
   host: "broker-sda-mq"
@@ -17,3 +11,8 @@ broker:
     files: files
     stableid: accessionIDs
 logLevel: debug
+tls:
+  secretName: orch-certs
+  cert: orch.crt
+  key: orch.key
+  caCert: ca.crt

--- a/dev_tools/scripts/sda/deploy-orch.sh
+++ b/dev_tools/scripts/sda/deploy-orch.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -e
 
-DB_IN_PASS=$(grep pg_in_password sda-deploy-init/config/trace.yml | awk '{print $2}' | sed -e 's/\"//g')
-DB_OUT_PASS=$(grep pg_out_password sda-deploy-init/config/trace.yml | awk '{print $2}' | sed -e 's/\"//g')
+## sda-orch certs
+kubectl create secret generic orch-certs \
+--from-file=sda-deploy-init/config/certs/ca.crt \
+--from-file=sda-deploy-init/config/certs/orch.crt \
+--from-file=sda-deploy-init/config/certs/orch.key
 
-helm install orch charts/sda-orch -f dev_tools/config/orch.yaml \
---set db.passIngest="$DB_IN_PASS",\
-db.passOutgest="$DB_OUT_PASS"
+helm install orch charts/sda-orch -f dev_tools/config/orch.yaml

--- a/dev_tools/scripts/svc-setup.sh
+++ b/dev_tools/scripts/svc-setup.sh
@@ -7,10 +7,6 @@ basedir="sda-deploy-init/config"
 cp "${basedir}"/certs/public.crt public.crt
 cp "${basedir}"/certs/private.key private.key
 
-## sda-orch certs
-cp "${basedir}"/certs/orch.crt charts/sda-orch/files/orch.crt
-cp "${basedir}"/certs/orch.key charts/sda-orch/files/orch.key
-
 ## cega config and certs
 mkdir -p LocalEGA-helm/ega-charts/cega/config/certs
 cp -r dev_tools/cega/* LocalEGA-helm/ega-charts/cega/config/
@@ -33,8 +29,5 @@ for n in backup doa finalize ingest intercept verify mapper inbox auth
   cp "${basedir}"/certs/$n.key charts/sda-svc/files/$n.key
 done
 
-for p in sda-svc sda-orch
-  do 
-  cp "${basedir}"/certs/ca.crt "charts/$p/files/ca.crt"
-  cp "${basedir}"/certs/tester.* "charts/$p/files/"
-done
+cp "${basedir}"/certs/ca.crt "charts/sda-svc/files/ca.crt"
+cp "${basedir}"/certs/tester.* "charts/sda-svc/files/"


### PR DESCRIPTION
**Needs to be rebased once #101 and #102 is merged**

This is part 2 in a series of PRs that will change how the charts are deployed.
Since all PRs are connected they need to be merged in series, hence the next will be created once this one is merged.

This is a breaking change, older versions of the values file will not work any more.

Changes made
Chart version bumped to v0.7.0
Moved the default container repo from Docker Hub to GitHub Container Repository
The chart can now be deployed with TLS disabled by setting tls.enabled=false
Secret for the servers TLS certificates will have to be created manually from now on. This is in order to facilitate a smoother deployment, i.e. `helm install orch neicnordic/sda-orch -f values.yaml`