### PR TITLE
add sda-download to helm charts [ part 2 of 3 ] 

### DIFF
--- a/.github/workflows/sda-orch.yml
+++ b/.github/workflows/sda-orch.yml
@@ -3,7 +3,7 @@ name: sda standalone deployment
 on: [push,pull_request]
 
 env:
-  svc_list: 'auth backup doa finalize inbox ingest mapper verify'
+  svc_list: 'auth backup doa download finalize inbox ingest mapper verify'
 
 jobs:
   build:

--- a/.github/workflows/sda-pipeline.yml
+++ b/.github/workflows/sda-pipeline.yml
@@ -18,7 +18,7 @@ jobs:
         if [ "${{ matrix.test }}" = "sftp-inbox" ]; then
           echo "SVCS=backup doa download finalize inbox ingest intercept mapper verify" >> "$GITHUB_ENV";
         else
-          echo "SVCS=auth backup doa finalize inbox ingest mapper verify" >> "$GITHUB_ENV";
+          echo "SVCS=auth backup doa download finalize inbox ingest mapper verify" >> "$GITHUB_ENV";
         fi
     - uses: actions/checkout@v2
     - name: Install kube dependencies

--- a/charts/sda-svc/templates/doa-deploy.yaml
+++ b/charts/sda-svc/templates/doa-deploy.yaml
@@ -146,7 +146,7 @@ spec:
         - name: CRYPT4GH_PRIVATE_KEY_PASSWORD_PATH
           value: "{{ template "c4ghPath" . }}/passphrase"
         - name: OPENID_CONFIGURATION_URL
-          value: "{{ .Values.global.elixir.oidcdHost }}.well-known/openid-configuration"
+          value: "{{ .Values.global.elixir.oidcdHost }}/.well-known/openid-configuration"
         - name: OUTBOX_ENABLED
           value: {{ .Values.global.doa.outbox.enabled | quote }}
       {{- if .Values.global.doa.outbox.enabled }}

--- a/charts/sda-svc/templates/download-deploy.yaml
+++ b/charts/sda-svc/templates/download-deploy.yaml
@@ -1,4 +1,3 @@
-{{- if eq "posix" .Values.global.archive.storageType }}
 {{- if or (or (eq "all" .Values.global.deploymentType) (eq "external" .Values.global.deploymentType) ) (not .Values.global.deploymentType) }}
 apiVersion: apps/v1
 kind: Deployment
@@ -68,11 +67,27 @@ spec:
         command: ["sda-download"]
         env:
         - name: ARCHIVE_TYPE
+        {{- if eq "s3" .Values.global.archive.storageType }}
+          value: "s3"
+        - name: ARCHIVE_URL
+          value: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
+        - name: ARCHIVE_BUCKET
+          value: {{ required "S3 archive bucket missing" .Values.global.archive.s3Bucket }}
+        - name: ARCHIVE_REGION
+          value: {{ default "us-east-1" .Values.global.archive.s3Region }}
+        - name: ARCHIVE_CHUNKSIZE
+          value: {{ .Values.global.archive.s3ChunkSize | quote }}
+        {{- if .Values.global.archive.s3CaFile }}
+        - name: ARCHIVE_CACERT
+          value: {{ template "tlsPath" . }}/{{ .Values.global.archive.s3CaFile }}
+        {{- end }}
+      {{- else }}
           value: "posix"
         - name: ARCHIVE_LOCATION
-          value: "{{ .Values.global.archive.volumePath }}/"
+          value: "{{ .Values.global.archive.volumePath }}"
+      {{- end }}
         - name: OIDC_CONFIGURATION_URL
-          value: "{{ .Values.global.elixir.oidcdHost }}.well-known/openid-configuration"
+          value: "{{ .Values.global.elixir.oidcdHost }}/.well-known/openid-configuration"
         - name: C4GH_FILEPATH
           value: {{ template "c4ghPath" . }}/{{ default "c4gh.sec.pem" .Values.global.c4gh.file }}
       {{- if or (eq "verify-ca" .Values.global.db.sslMode) (eq "verify-full" .Values.global.db.sslMode) }}
@@ -102,6 +117,18 @@ spec:
         - name: SESSION_EXPIRATION
           value: {{ .Values.global.download.sessionExpiration | quote }}
       {{- if not .Values.global.vaultSecrets }}
+        {{- if eq "s3" .Values.global.archive.storageType }}
+        - name: ARCHIVE_ACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sda.fullname" . }}-s3archive-keys
+              key: s3ArchiveAccessKey
+        - name: ARCHIVE_SECRETKEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sda.fullname" . }}-s3archive-keys
+              key: s3ArchiveSecretKey
+        {{- end }}
         - name: C4GH_PASSPHRASE
           valueFrom:
             secretKeyRef:
@@ -156,8 +183,10 @@ spec:
         - name: tls
           mountPath: {{ template "tlsPath" . }}
         {{- end }}
+        {{- if eq "posix" .Values.global.archive.storageType }}
         - name: archive
           mountPath: {{ .Values.global.archive.volumePath | quote }}
+        {{- end }}
       volumes:
       {{- if not .Values.global.pkiService }}
         - name: {{ ternary "tls" "tls-certs" (empty .Values.global.pkiPermissions) }}
@@ -192,5 +221,4 @@ spec:
         {{- end }}
       {{- end }}
       restartPolicy: Always
-{{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/download-ingress.yaml
+++ b/charts/sda-svc/templates/download-ingress.yaml
@@ -1,4 +1,3 @@
-{{- if eq "posix" .Values.global.archive.storageType }}
 {{- if (or (or (eq "all" .Values.global.deploymentType) (eq "external" .Values.global.deploymentType)) (not .Values.global.deploymentType)) }}
 {{- if .Values.global.ingress.deploy }}
 apiVersion: networking.k8s.io/v1
@@ -36,6 +35,5 @@ spec:
   - hosts:
     - {{ required "An ingress hostname is required!" .Values.global.ingress.hostName.download }}
     secretName: {{ if .Values.global.ingress.secretNames.download }}{{ .Values.global.ingress.secretNames.download }}{{- else }}"{{ template "sda.fullname" . }}-ingress-download"{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/download-secrets.yaml
+++ b/charts/sda-svc/templates/download-secrets.yaml
@@ -1,4 +1,3 @@
-{{- if eq "posix" .Values.global.archive.storageType }}
 {{- if or (or (eq "all" .Values.global.deploymentType) (eq "external" .Values.global.deploymentType) ) (not .Values.global.deploymentType) }}
 {{- if not .Values.global.vaultSecrets }}
 apiVersion: v1
@@ -21,6 +20,5 @@ metadata:
 data:
 {{ ( .Files.Glob "files/ca.crt" ).AsSecrets | trim | indent 2 }}
 {{ ( $download ).AsSecrets | indent 2 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/download-service.yaml
+++ b/charts/sda-svc/templates/download-service.yaml
@@ -1,4 +1,3 @@
-{{- if eq "posix" .Values.global.archive.storageType }}
 {{- if or (or (eq "all" .Values.global.deploymentType) (eq "external" .Values.global.deploymentType) ) (not .Values.global.deploymentType) }}
 apiVersion: v1
 kind: Service
@@ -14,5 +13,4 @@ spec:
     protocol: TCP
   selector:
     app: {{ template "sda.fullname" . }}-download
-{{- end }}
 {{- end }}

--- a/charts/sda-svc/test/release-test.sh
+++ b/charts/sda-svc/test/release-test.sh
@@ -30,10 +30,7 @@ if [ "${DEPLOYMENT_TYPE}" = all -o "${DEPLOYMENT_TYPE}" = external ]; then
 
     echo "DOA seems okay"
 
-
-    if [ "${ARCHIVE_STORAGE_TYPE}" = posix ]; then
-      python3 /release-test-app/verify-download.py
-    fi
+    python3 /release-test-app/verify-download.py
 
     if [ "$?" -ne 0 ]; then
 	echo "Failed download verification, bailing out"

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -335,7 +335,7 @@ download:
   name: download
   replicaCount: 1
   repository: ghcr.io/neicnordic/sda-download
-  imageTag: v1.3.0
+  imageTag: v1.4.0
   imagePullPolicy: IfNotPresent
   resources:
     requests:

--- a/dev_tools/config/s3.yaml
+++ b/dev_tools/config/s3.yaml
@@ -58,6 +58,7 @@ global:
   ingress:
     hostName:
       auth: sda-sda-svc-auth
+      download: sda-sda-svc-download
   logLevel: debug
 backup:
   deploy: true


### PR DESCRIPTION
This is part 2 in a series of PRs that will add sda-download to helm charts (ultimately with the purpose of replace sda-doa)
depends on the changes in https://github.com/neicnordic/sda-download/pull/77

This is not a breaking change.
Changes made:
* added `sda-download` to the charts with the option to start with s3 storage
* enable basic tests for the `sda-download` endpoint for s3

known limitations:
* https is missing till it is implemented in `sda-download`

