### PR TITLE
add sda-download to helm charts [ part 3 of 3 ]

### DIFF
--- a/charts/sda-svc/templates/_helpers.yaml
+++ b/charts/sda-svc/templates/_helpers.yaml
@@ -105,6 +105,10 @@ Create chart name and version as used by the chart label.
 {{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.c4ghPath) (empty .Values.global.c4ghPath) -}}
 {{- end -}}
 
+{{- define "trustedIssPath" -}}
+{{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.download.trusted.configPath) (empty .Values.global.download.trusted.configPath) -}}
+{{- end -}}
+
 {{- define "tlsPath" -}}
 {{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.tlsPath) (empty .Values.global.tlsPath) -}}
 {{- end -}}

--- a/charts/sda-svc/templates/download-deploy.yaml
+++ b/charts/sda-svc/templates/download-deploy.yaml
@@ -112,6 +112,14 @@ spec:
         - name: LOG_LEVEL
           value: {{ .Values.global.logLevel | quote }}
       {{- end }}
+      {{- if .Values.global.download.useTLS }}
+        - name: APP_PORT
+          value: "8443"
+        - name: APP_SERVERCERT
+          value: "{{ template "tlsPath" . }}/download.crt"
+        - name: APP_SERVERKEY
+          value: "{{ template "tlsPath" . }}/download.key"
+      {{- end }}
         - name: SESSION_DOMAIN
           value: {{ .Values.global.ingress.hostName.download | quote }}
         - name: SESSION_EXPIRATION
@@ -150,7 +158,7 @@ spec:
       {{- end }}
         ports:
         - name: download
-          containerPort: 8080
+          containerPort: {{ ternary 8080 8443 ( empty .Values.global.download.useTLS ) }}
           protocol: TCP
         livenessProbe:
           httpGet:

--- a/charts/sda-svc/templates/download-deploy.yaml
+++ b/charts/sda-svc/templates/download-deploy.yaml
@@ -88,6 +88,10 @@ spec:
       {{- end }}
         - name: OIDC_CONFIGURATION_URL
           value: "{{ .Values.global.elixir.oidcdHost }}/.well-known/openid-configuration"
+      {{- if .Values.global.download.trusted.iss }}
+        - name: OIDC_TRUSTED_ISS
+          value: {{ include "trustedIssPath" . }}/{{ default "iss.json" .Values.global.download.trusted.configFile }}
+      {{- end }}
         - name: C4GH_FILEPATH
           value: {{ template "c4ghPath" . }}/{{ default "c4gh.sec.pem" .Values.global.c4gh.file }}
       {{- if or (eq "verify-ca" .Values.global.db.sslMode) (eq "verify-full" .Values.global.db.sslMode) }}
@@ -183,9 +187,11 @@ spec:
         resources:
 {{ toYaml .Values.download.resources | trim | indent 10 }}
         volumeMounts:
-       {{- if not .Values.global.vaultSecrets }}
+        {{- if not .Values.global.vaultSecrets }}
         - name: c4gh
           mountPath: {{ template "c4ghPath" . }}
+        - name: iss
+          mountPath: {{ template "trustedIssPath" . }}
         {{- end }}
         {{- if not .Values.global.pkiService }}
         - name: tls
@@ -216,6 +222,13 @@ spec:
             items:
             - key: {{ .Values.global.c4gh.file }}
               path: {{ .Values.global.c4gh.file }}
+        - name: iss
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-download-iss
+            items:
+            - key: {{ .Values.global.download.trusted.configFile }}
+              path: {{ .Values.global.download.trusted.configFile }}
       {{- end }}
       {{- if eq "posix" .Values.global.archive.storageType }}
         - name: archive

--- a/charts/sda-svc/templates/download-secrets.yaml
+++ b/charts/sda-svc/templates/download-secrets.yaml
@@ -9,6 +9,14 @@ data:
   dbPassword: {{ include "dbPassDownload" . | b64enc }}
   c4ghPassphrase: {{ .Values.global.c4gh.passphrase | b64enc }}
   dbUser: {{ include "dbUserDownload" . | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sda.fullname" . }}-download-iss
+type: Opaque
+data:
+  iss.json: {{ .Values.global.download.trusted.iss | toJson | b64enc | quote }}
 {{- end }}
 {{- if not .Values.global.pkiService }}
 ---

--- a/charts/sda-svc/test/verify-download.py
+++ b/charts/sda-svc/test/verify-download.py
@@ -9,10 +9,10 @@ import urllib.error
 
 backendhost = os.environ.get('DOWNLOAD_SERVICE_NAME','localhost')
 
-print("Will try connecting to %s:8080" % backendhost)
+print("Will try connecting to %s:443" % backendhost)
 
 try:
-    r = urllib.request.urlopen('http://%s:8080/files' % backendhost, context=ssl._create_unverified_context())
+    r = urllib.request.urlopen('https://%s:443/files' % backendhost, context=ssl._create_unverified_context())
     sys.exit(0)
 except urllib.error.HTTPError as e:
     if e.code == 404:

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -192,6 +192,14 @@ global:
     # a positive integer enables sessions
     # a negative integer disables sessions
     sessionExpiration: 28800
+    # this should translate into JSON array of objects
+    # with 2 keys iss and jku
+    trusted:
+      configPath: ""
+      configFile: "iss.json"
+      iss:
+        - iss: "https://login.elixir-czech.org/oidc/"
+          jku: "https://login.elixir-czech.org/oidc/jwk"
 
   elixir:
     oidcdHost: "https://login.elixir-czech.org/oidc/"

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -186,7 +186,7 @@ global:
     envFile: env
 
   download:
-    useTLS: false
+    useTLS: true
     # session key expiration time in seconds
     # default value = -1 for disabled state
     # a positive integer enables sessions
@@ -335,7 +335,7 @@ download:
   name: download
   replicaCount: 1
   repository: ghcr.io/neicnordic/sda-download
-  imageTag: v1.4.0
+  imageTag: v1.5.0
   imagePullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
This is part 3 in a series of PRs that will add sda-download to helm charts (ultimately with the purpose of replace sda-doa)
depends on the changes in neicnordic/sda-download#78

This is not a breaking change.
Changes made:

- added support for tls
- use web_app port `8443` in container as `443` is forbidden
- test with 443 port
