### PR TITLE
K8s >= 1.25 compatibility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3.3.0
     - name: Install helm3
-      run: |
-        wget https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O - | tar -xz
-        sudo cp linux-amd64/helm /usr/local/bin/helm
+      run: bash ./dev_tools/scripts/install-kube-deps.sh
     - name: Lint sda-db
       run: helm lint charts/sda-db
 
@@ -21,9 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3.3.0
     - name: Install helm3
-      run: |
-        wget https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O - | tar -xz
-        sudo cp linux-amd64/helm /usr/local/bin/helm
+      run: bash ./dev_tools/scripts/install-kube-deps.sh
     - name: Lint sda-mq
       run: helm lint charts/sda-mq
 
@@ -33,9 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3.3.0
     - name: Install helm3
-      run: |
-        wget https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O - | tar -xz
-        sudo cp linux-amd64/helm /usr/local/bin/helm
+      run: bash ./dev_tools/scripts/install-kube-deps.sh
     - name: Lint sda-svc
       run: helm lint charts/sda-svc
 
@@ -45,8 +39,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3.3.0
     - name: Install helm3
-      run: |
-        wget https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O - | tar -xz
-        sudo cp linux-amd64/helm /usr/local/bin/helm
+      run: bash ./dev_tools/scripts/install-kube-deps.sh
     - name: Lint sda-orch
       run: helm lint charts/sda-orch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
     - name: Install helm3
       run: |
-        wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz -O - | tar -xz
+        wget https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O - | tar -xz
         sudo cp linux-amd64/helm /usr/local/bin/helm
     - name: Lint sda-db
       run: helm lint charts/sda-db
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
     - name: Install helm3
       run: |
-        wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz -O - | tar -xz
+        wget https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O - | tar -xz
         sudo cp linux-amd64/helm /usr/local/bin/helm
     - name: Lint sda-mq
       run: helm lint charts/sda-mq
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
     - name: Install helm3
       run: |
-        wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz -O - | tar -xz
+        wget https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O - | tar -xz
         sudo cp linux-amd64/helm /usr/local/bin/helm
     - name: Lint sda-svc
       run: helm lint charts/sda-svc
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v3.3.0
     - name: Install helm3
       run: |
-        wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz -O - | tar -xz
+        wget https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O - | tar -xz
         sudo cp linux-amd64/helm /usr/local/bin/helm
     - name: Lint sda-orch
       run: helm lint charts/sda-orch

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 This repositroy contains helmcharts for deploying a Sensitive Data Archive solution that is compatible with the European Genome Archives federated archiving model.
 
+The charts are compatible with kubernetes versions >= 1.19.0 and are tested against kubernetes version 1.25.6
+
 ## sda-db
 
 This chart deploys a pre-configured database instance for Sensitive Data Archive, the schemas match European Genome Archives federated archiving model.

--- a/charts/sda-db/Chart.yaml
+++ b/charts/sda-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-db
-version: "0.5.0"
+version: "0.5.1"
 description: Database component for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io
 icon: https://neic.no/assets/images/logo.png

--- a/charts/sda-db/templates/podsecuritypolicy.yaml
+++ b/charts/sda-db/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "<v1.25.0" .Capabilities.KubeVersion.Version }}
 {{- if and .Values.rbacEnabled .Values.securityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -65,4 +66,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/sda-mq/Chart.yaml
+++ b/charts/sda-mq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-mq
-version: "0.4.4"
+version: "0.4.5"
 description: RabbitMQ component for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io
 icon: https://neic.no/assets/images/logo.png

--- a/charts/sda-mq/templates/podsecuritypolicy.yaml
+++ b/charts/sda-mq/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "<v1.25.0" .Capabilities.KubeVersion.Version }}
 {{- if and .Values.rbacEnabled .Values.securityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -64,4 +65,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/sda-mq/templates/release-test-deploy.yaml
+++ b/charts/sda-mq/templates/release-test-deploy.yaml
@@ -1,15 +1,14 @@
----
 {{- define "mqfullname" -}}
 {{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+  {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+  {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 apiVersion: v1

--- a/charts/sda-orch/Chart.yaml
+++ b/charts/sda-orch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-orch
-version: "0.7.4"
+version: "0.7.5"
 description: Orchestrate component for Sensitive Data Archive (SDA) standalone installation
 home: https://neic-sda.readthedocs.io
 icon: https://neic.no/assets/images/logo.png

--- a/charts/sda-orch/templates/podsecuritypolicy.yaml
+++ b/charts/sda-orch/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "<v1.25.0" .Capabilities.KubeVersion.Version }}
 {{- if and .Values.rbacEnabled .Values.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -37,4 +38,5 @@ spec:
   - configMap
   - emptyDir
   - projected
+{{- end }}
 {{- end }}

--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: "0.18.4"
+version: "0.18.5"
 kubeVersion: ">= 1.19.0"
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sda-svc
 version: "0.18.5"
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io
 icon: https://neic.no/assets/images/logo.png

--- a/charts/sda-svc/templates/podsecuritypolicy.yaml
+++ b/charts/sda-svc/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "<v1.25.0" .Capabilities.KubeVersion.Version }}
 {{- if and .Values.global.rbacEnabled .Values.global.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -65,4 +66,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/dev_tools/scripts/init-k3d.sh
+++ b/dev_tools/scripts/init-k3d.sh
@@ -2,14 +2,14 @@
 
 if ! command -v k3d > /dev/null
 then
-  wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v4.4.6 bash
+  wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.4.6 bash
 fi
 
 k3d cluster list | grep "sda"
 cluster_exists=$?
 
 if [ $cluster_exists -ne 0 ]; then
-  sudo k3d cluster create sda
+  sudo k3d cluster create sda --image=rancher/k3s:v1.25.6-rc1-k3s1-amd64
   sudo k3d kubeconfig merge sda --kubeconfig-switch-context
   sudo mkdir -p ~/.kube/ && sudo cp /root/.k3d/kubeconfig-sda.yaml ~/.kube/config
   sudo chmod 666 ~/.kube/config

--- a/dev_tools/scripts/install-kube-deps.sh
+++ b/dev_tools/scripts/install-kube-deps.sh
@@ -7,7 +7,7 @@ elif [ "$OSTYPE" == "darwin" ]; then
   BTYPE="darwin"
 fi
 
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/"$BTYPE"/amd64/kubectl
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.0/bin/"$BTYPE"/amd64/kubectl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 

--- a/dev_tools/scripts/install-kube-deps.sh
+++ b/dev_tools/scripts/install-kube-deps.sh
@@ -11,7 +11,7 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/"
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 
-wget https://get.helm.sh/helm-v3.4.2-"$BTYPE"-amd64.tar.gz -O - | tar -xz
+wget https://get.helm.sh/helm-v3.11.0-"$BTYPE"-amd64.tar.gz -O - | tar -xz
 sudo cp "$BTYPE"-amd64/helm /usr/local/bin/helm
 
 rm -r ./*-amd64/


### PR DESCRIPTION
This enables deployment in a cluster with version >= 1.25.

Kubernetes 1.24 is the last version that makes use of `Pod Security Policies`, it will be EOL in 6 months.
The actual yaml files can be removed after 1.24 has reached EOL.

Tests are now run against k8s 1.25.6