### PR TITLE
Update db ssl mode to match documentation

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: "0.18.5"
+version: "0.18.6"
 kubeVersion: ">= 1.19.0-0"
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -186,7 +186,7 @@ global:
     passIngest: ""
     passOutgest: ""
     port: 5432
-    sslMode: "verify-ca"
+    sslMode: "verify-full"
 
   doa:
     enabled: false


### PR DESCRIPTION
The documentation for `sda-svc` points states that the default value for the ssl mode (`global.db.sslMode`) defaults to `verify-full`, however, the values file defaults to `verify-ca`. The pr fixes this issue by updating the value in the `values.yaml` file