### PR TITLE
Add buffering to ingress

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: "0.18.6"
+version: "0.18.7"
 kubeVersion: ">= 1.19.0-0"
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/templates/s3-inbox-ingress.yaml
+++ b/charts/sda-svc/templates/s3-inbox-ingress.yaml
@@ -17,7 +17,8 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: "/"
     nginx.ingress.kubernetes.io/backend-protocol: "{{ ternary "HTTPS" "HTTP" .Values.global.tls.enabled }}"
     nginx.ingress.kubernetes.io/proxy-body-size: 2000m
-    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: 300s
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "on"
     {{- end }}
     {{- if .Values.global.ingress.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.ingress.clusterIssuer | quote }}


### PR DESCRIPTION
During uploads from a bit slower connections users have reported 500/502 errors.
This was what seems due to passing incomplete data packages to the backend. Adding request buffering to the ingress has solved the issues.

fixes: #159 