### PR TITLE
add resignJwt option to auth

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: "0.18.8"
+version: "0.18.9"
 kubeVersion: ">= 1.19.0-0"
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -75,6 +75,7 @@ Parameter | Description | Default
 `global.auth.jwtAlg` | Key type to sign the JWT, available options are RS265 & ES256, Must match the key type |`"ES256"`
 `global.auth.jwtKey` | Private key used to sign the JWT. |`""`
 `global.auth.jwtPub` | Public key ues to verify the JWT. |`""`
+`global.auth.resignJWT` | Resign the LS-AAI JWTs. |`true`
 `global.auth.useTLS` | Run a TLS secured server. |`true`
 `global.auth.corsOrigins` | Domain name allowed for cross-domain requests. |`""`
 `global.auth.corsMethods` | Allowed cross-domain request methods. |`""`

--- a/charts/sda-svc/templates/auth-deploy.yaml
+++ b/charts/sda-svc/templates/auth-deploy.yaml
@@ -131,6 +131,8 @@ spec:
           value: "{{ template "jwtPath" . }}/{{ .Values.global.auth.jwtKey }}"
         - name: JWTSIGNATUREALG
           value: {{ .Values.global.auth.jwtAlg }}
+        - name: RESIGNJWT
+          value: {{ .Values.global.auth.resignJwt | quote }}
         {{- if .Values.global.tls.enabled}}
         - name: SERVER_CERT
           value: {{ template "tlsPath" . }}/tls.crt

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -149,6 +149,8 @@ global:
     jwtKey:
     # @param jwtPub, name of the public signing key
     jwtPub:
+    # @param resignJwt, if true (or empty) the jwt will be resigned with the jwtKey
+    resignJwt: true
     # @param corsOrigins, domain name of allowed origin for cross-domain requests
     corsOrigins: ""
     # @param corsMethods, allowed methods for cross-domain requests


### PR DESCRIPTION
The goal is to have `auth` serve only the original LS-AAI access token in the future, however at the moment LS-AAI 's tokens last for 1 hour, so the default is set to `true`.